### PR TITLE
Replace "async-shell-command" to "compile"

### DIFF
--- a/test-kitchen.el
+++ b/test-kitchen.el
@@ -4,7 +4,7 @@
 ;; Author: JJ Asghar
 ;; URL: http://github.com/jjasghar/test-kitchen-el
 ;; Created: 2015
-;; Version: 0.2.1
+;; Version: 0.3.0
 ;; Keywords: chef ruby test-kitchen
 
 ;; This file is NOT part of GNU Emacs.
@@ -75,6 +75,14 @@
 ;;; test kitchen is very likes colors, so colorize compilation buffer
 (require 'ansi-color)
 
+(defadvice display-message-or-buffer (before ansi-color activate)
+  "Process ANSI color codes in shell output."
+  (let ((buf (ad-get-arg 0)))
+    (and (bufferp buf)
+	 (string-match "^\\*kitchen.*\\*" (buffer-name buf))
+	 (with-current-buffer buf
+	              (ansi-color-apply-on-region (point-min) (point-max))))))
+
 (defun test-kitchen-colorize-compilation-buffer ()
   (toggle-read-only)
   (ansi-color-apply-on-region compilation-filter-start (point))
@@ -92,10 +100,17 @@
           (compile cmd 'test-kitchen-compilation-mode))
       (error "Couldn't locate .kitchen.yml!"))))
 
+(defun test-kitchen-run-to-string (cmd)
+  (let ((root-dir (test-kitchen-locate-root-dir)))
+    (if root-dir
+        (let ((default-directory root-dir))
+          (shell-command-to-string cmd))
+      (error "Couldn't locate .kitchen.yml!"))))
+
 ;;;###autoload
 (defun test-kitchen-destroy (instance)
   "Run chef exec kitchen destroy in a different buffer."
-  (interactive "sKitchen instance to destroy: ")
+  (interactive (list (completing-read "Kitchen instance to destroy: " (split-string (test-kitchen-list-bare)))))
   (test-kitchen-run (concat test-kitchen-destroy-command " " instance)))
 
 ;;;###autoload
@@ -104,16 +119,27 @@
   (interactive)
   (test-kitchen-run test-kitchen-destroy-command))
 
+(defun test-kitchen-list-update-cache ()
+  (test-kitchen-run-to-string
+   (concat "DIR=$(echo $PWD | sed \'s/\\\//_/g\'); [[ .kitchen.yml -nt /tmp/${DIR}_kitchen.list.yml || .kitchen.local.yml -nt /tmp/${DIR}_kitchen.list.yml ]] && " test-kitchen-list-command " -b >/tmp/${DIR}_kitchen.list.yml 2>/dev/null")))
+
+;;;###autoload
+(defun test-kitchen-list-bare ()
+  "Run chef exec kitchen list in a different buffer."
+  (test-kitchen-list-update-cache)
+  (test-kitchen-run-to-string "DIR=$(echo $PWD | sed \'s/\\\//_/g\'); cat /tmp/${DIR}_kitchen.list.yml"))
+
 ;;;###autoload
 (defun test-kitchen-list ()
   "Run chef exec kitchen list in a different buffer."
   (interactive)
-  (test-kitchen-run test-kitchen-list-command))
+  (with-output-to-temp-buffer "*kitchen-list*"
+    (princ (test-kitchen-run-to-string (concat test-kitchen-list-command " --color 2>/dev/null")))))
 
 ;;;###autoload
 (defun test-kitchen-test (instance)
   "Run chef exec kitchen test in a different buffer."
-  (interactive "sKitchen instance to perform test: ")
+  (interactive (list (completing-read "Kitchen instance to perform test: " (split-string (test-kitchen-list-bare)))))
   (test-kitchen-run (concat test-kitchen-test-command " " instance)))
 
 ;;;###autoload
@@ -125,7 +151,7 @@
 ;;;###autoload
 (defun test-kitchen-converge (instance)
   "Run chef exec kitchen converge selected VM in a different buffer."
-  (interactive "sKitchen instance to converge: ")
+  (interactive (list (completing-read "Kitchen instance to converge: " (split-string (test-kitchen-list-bare)))))
   (test-kitchen-run (concat test-kitchen-converge-command " " instance)))
 
 ;;;###autoload
@@ -137,7 +163,7 @@
 ;;;###autoload
 (defun test-kitchen-verify (instance)
   "Run chef exec kitchen verify in a different buffer."
-  (interactive "sKitchen instance to verify: ")
+  (interactive (list (completing-read "Kitchen instance to verify: " (split-string (test-kitchen-list-bare)))))
   (test-kitchen-run (concat test-kitchen-verify-command " " instance)))
 
 ;;;###autoload

--- a/test-kitchen.el
+++ b/test-kitchen.el
@@ -111,7 +111,12 @@
   (test-kitchen-run test-kitchen-test-command))
 
 ;;;###autoload
-(defun test-kitchen-converge ()
+(defun test-kitchen-converge (instance)
+  "Run chef exec kitchen converge selected VM in a different buffer."
+  (interactive "sKitchen instance to converge: ")
+  (test-kitchen-run (concat test-kitchen-converge-command " " instance)))
+
+(defun test-kitchen-converge-all ()
   "Run chef exec kitchen converge in a different buffer."
   (interactive)
   (test-kitchen-run test-kitchen-converge-command))
@@ -121,7 +126,6 @@
   "Run chef exec kitchen verify in a different buffer."
   (interactive)
   (test-kitchen-run test-kitchen-verify-command))
-
 
 (provide 'test-kitchen)
 ;;; test-kitchen.el ends here

--- a/test-kitchen.el
+++ b/test-kitchen.el
@@ -116,13 +116,20 @@
   (interactive "sKitchen instance to converge: ")
   (test-kitchen-run (concat test-kitchen-converge-command " " instance)))
 
+;;;###autoload
 (defun test-kitchen-converge-all ()
   "Run chef exec kitchen converge in a different buffer."
   (interactive)
   (test-kitchen-run test-kitchen-converge-command))
 
 ;;;###autoload
-(defun test-kitchen-verify ()
+(defun test-kitchen-verify (instance)
+  "Run chef exec kitchen verify in a different buffer."
+  (interactive "sKitchen instance to converge: ")
+  (test-kitchen-run (concat test-kitchen-verify-command " " instance)))
+
+;;;###autoload
+(defun test-kitchen-verify-all ()
   "Run chef exec kitchen verify in a different buffer."
   (interactive)
   (test-kitchen-run test-kitchen-verify-command))

--- a/test-kitchen.el
+++ b/test-kitchen.el
@@ -75,18 +75,21 @@
 ;;; test kitchen is very likes colors, so colorize compilation buffer
 (require 'ansi-color)
 
-(defun colorize-compilation-buffer ()
+(defun test-kitchen-colorize-compilation-buffer ()
   (toggle-read-only)
   (ansi-color-apply-on-region compilation-filter-start (point))
   (toggle-read-only))
 
-(add-hook 'compilation-filter-hook 'colorize-compilation-buffer)
+;; define test kitchen compilation mode
+(define-compilation-mode test-kitchen-compilation-mode "Test Kitchen compilation"
+  "Compilation mode for RSpec output."
+  (add-hook 'compilation-filter-hook 'test-kitchen-colorize-compilation-buffer nil t))
 
 (defun test-kitchen-run (cmd)
   (let ((root-dir (test-kitchen-locate-root-dir)))
     (if root-dir
         (let ((default-directory root-dir))
-          (compile cmd))
+          (compile cmd 'test-kitchen-compilation-mode))
       (error "Couldn't locate .kitchen.yml!"))))
 
 ;;;###autoload

--- a/test-kitchen.el
+++ b/test-kitchen.el
@@ -72,6 +72,16 @@
                            (file-name-directory buffer-file-name))
                           ".kitchen.yml"))
 
+;;; test kitchen is very likes colors, so colorize compilation buffer
+(require 'ansi-color)
+
+(defun colorize-compilation-buffer ()
+  (toggle-read-only)
+  (ansi-color-apply-on-region compilation-filter-start (point))
+  (toggle-read-only))
+
+(add-hook 'compilation-filter-hook 'colorize-compilation-buffer)
+
 (defun test-kitchen-run (cmd)
   (let ((root-dir (test-kitchen-locate-root-dir)))
     (if root-dir

--- a/test-kitchen.el
+++ b/test-kitchen.el
@@ -75,10 +75,8 @@
 (defun test-kitchen-run (cmd)
   (let ((root-dir (test-kitchen-locate-root-dir)))
     (if root-dir
-        (let ((default-directory root-dir)
-              (out-buffer (get-buffer-create "*chef output*")))
-          (async-shell-command cmd out-buffer)
-          (display-buffer out-buffer))
+        (let ((default-directory root-dir))
+          (compile cmd))
       (error "Couldn't locate .kitchen.yml!"))))
 
 ;;;###autoload

--- a/test-kitchen.el
+++ b/test-kitchen.el
@@ -93,7 +93,13 @@
       (error "Couldn't locate .kitchen.yml!"))))
 
 ;;;###autoload
-(defun test-kitchen-destroy ()
+(defun test-kitchen-destroy (instance)
+  "Run chef exec kitchen destroy in a different buffer."
+  (interactive "sKitchen instance to destroy: ")
+  (test-kitchen-run (concat test-kitchen-destroy-command " " instance)))
+
+;;;###autoload
+(defun test-kitchen-destroy-all ()
   "Run chef exec kitchen destroy in a different buffer."
   (interactive)
   (test-kitchen-run test-kitchen-destroy-command))
@@ -105,7 +111,13 @@
   (test-kitchen-run test-kitchen-list-command))
 
 ;;;###autoload
-(defun test-kitchen-test ()
+(defun test-kitchen-test (instance)
+  "Run chef exec kitchen test in a different buffer."
+  (interactive "sKitchen instance to perform test: ")
+  (test-kitchen-run (concat test-kitchen-test-command " " instance)))
+
+;;;###autoload
+(defun test-kitchen-test-all ()
   "Run chef exec kitchen test in a different buffer."
   (interactive)
   (test-kitchen-run test-kitchen-test-command))
@@ -125,7 +137,7 @@
 ;;;###autoload
 (defun test-kitchen-verify (instance)
   "Run chef exec kitchen verify in a different buffer."
-  (interactive "sKitchen instance to converge: ")
+  (interactive "sKitchen instance to verify: ")
   (test-kitchen-run (concat test-kitchen-verify-command " " instance)))
 
 ;;;###autoload


### PR DESCRIPTION
Replace "async-shell-command" to more useful "compile" function with special ansi-colored compilation buffer. Can be used for handle kitchen errors (not implemented yet)
